### PR TITLE
remove global scope clutter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 before_script:
-  - npm run setup
   - npm install
 script:
   - npm run build


### PR DESCRIPTION
no need to install npm packages globally if running scripts inside `npm run`.
it looks for local bin files automatically before checking the global scope.

also, was there any reason the prelude-ls was a dependency and not a devDependency?

nice project structure!
