### PR TITLE
remove global scope clutter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 before_script:
-  - npm run setup
   - npm install
 script:
   - npm run build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "setup": "npm install -g livescript mocha",
     "compile": "lsc --no-header -b -c -o ./ src",
     "test": "mocha --compilers ls:livescript",
     "build": "npm run compile && npm run test"
@@ -35,10 +34,10 @@
     "url": "https://github.com/mabrasil/resistance.js/issues"
   },
   "homepage": "https://github.com/mabrasil/resistance.js",
-  "dependencies": {
-    "prelude-ls": "^1.1.2"
-  },
   "devDependencies": {
-    "chai": "^3.5.0"
+    "chai": "^3.5.0",
+    "livescript": "^1.4.0",
+    "mocha": "^2.4.5",
+    "prelude-ls": "^1.1.2"
   }
 }


### PR DESCRIPTION
no need to install npm packages globally if running scripts inside npm run.
it looks for local bin files automatically before checking the global scope.

also, was there any reason the prelude-ls was a dependency and not a devDependency?

nice project structure!
